### PR TITLE
管理者情報登録後、管理者ログイン画面にリダイレクトするよう修正

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -75,7 +75,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
1-1修正項目です。
管理者情報登録後、管理者ログイン画面に遷移することに加え、ダブルサブミット対策でリダイレクトするように修正しました。