### PR TITLE
管理者登録画面遷移を修正。

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -75,7 +75,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
管理者登録後、従業員一覧画面に飛んでしまう問題を修正しました。
ご確認お願いいたします。