### PR TITLE
(１-1)管理者登録後、ログイン画面に遷移するように変更しました

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -78,7 +78,6 @@ public class AdministratorController {
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
 		return "redirect:/";
-		// gitのpushのテスト
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -78,6 +78,7 @@ public class AdministratorController {
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
 		return "redirect:/";
+		// gitのpushのテスト
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
 # 要約
- 管理者登録後、従業員一覧画面に飛んでしまうバグの修
正。登録後、ログイン画面に遷移するように変更。（1-1 初級）

# 観点
- 今回特に困った点はありませんでした。ご確認よろしくお願いします。