### PR TITLE
(2-1)中級 ログイン者名表示

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -111,6 +111,7 @@ public class AdministratorController {
             redirectAttributes.addFlashAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
             return "redirect:/";
         }
+        session.setAttribute("administratorName", administrator.getName());
         return "redirect:/employee/showList";
     }
 

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -8,6 +8,9 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,11 +68,16 @@ public class AdministratorController {
     /**
      * 管理者情報を登録します.
      *
+     * 入力値エラーがあれば管理者登録画面にエラーメッセージを表示する.
+     *
      * @param form 管理者情報用フォーム
      * @return ログイン画面へリダイレクト
      */
     @PostMapping("/insert")
-    public String insert(InsertAdministratorForm form) {
+    public String insert(@Validated InsertAdministratorForm form, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            return "administrator/insert";
+        }
         Administrator administrator = new Administrator();
         // フォームからドメインにプロパティ値をコピー
         BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -74,7 +74,7 @@ public class AdministratorController {
         // フォームからドメインにプロパティ値をコピー
         BeanUtils.copyProperties(form, administrator);
         administratorService.insert(administrator);
-        return "employee/list";
+        return "redirect:/";
     }
 
     /////////////////////////////////////////////////////

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,5 +1,9 @@
 package com.example.form;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  *
@@ -9,14 +13,18 @@ public class InsertAdministratorForm {
     /**
      * 名前
      */
+    @NotBlank(message = "名前を入力してください。")
     private String name;
     /**
      * メールアドレス
      */
+    @NotBlank(message = "メールアドレスを入力してください。")
+    @Email(message = "メールアドレスの形式で入力してください。")
     private String mailAddress;
     /**
      * パスワード
      */
+    @Size(min = 8, message = "パスワードは8文字以上でなければいけません。")
     private String password;
 	
     public String getName() {

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -66,7 +66,7 @@
                     </li>
                 </ul>
                 <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
+              <span th:text="${session.administratorName}">山田太郎</span
               >さんこんにちは！ &nbsp;&nbsp;&nbsp;
                     <a
                             href="../administrator/login.html"

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -66,7 +66,7 @@
                     </li>
                 </ul>
                 <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
+              <span th:text="${session.administratorName}">山田太郎</span
               >さんこんにちは！ &nbsp;&nbsp;&nbsp;
                     <a
                             href="../administrator/login.html"


### PR DESCRIPTION
## 目的
- ログイン成功後、従業員一覧画面と従業員詳細画面に「〇〇さん　こんにちは！」と表示させたいが表示されないため。

closes #5 

## 変更内容
- ログイン成功後、セッションスコープに管理者の名前をセットする形に修正
- 従業員一覧画面と従業員詳細画面で、管理者の名前を表示する形に修正